### PR TITLE
fix random mouse movement

### DIFF
--- a/src/PointerLockControls_v2.js
+++ b/src/PointerLockControls_v2.js
@@ -113,6 +113,7 @@ class PointerLockControls extends EventDispatcher {
 }
 
 // event listeners
+
 function onMouseMove(event) {
 
     if (this.isLocked === false) return;
@@ -123,10 +124,9 @@ function onMouseMove(event) {
     const camera = this.camera;
     _euler.setFromQuaternion(camera.quaternion);
 
-    const eY = movementX * this.pointerSpeed; // * defer multiply 0.002 to fix random mouse jump skipping
-    _euler.y -= eY * 0.002;
-    
+    _euler.y -= movementX * 0.002 * this.pointerSpeed;
     _euler.x -= movementY * 0.002 * this.pointerSpeed;
+
     _euler.x = Math.max(_PI_2 - this.maxPolarAngle, Math.min(_PI_2 - this.minPolarAngle, _euler.x));
 
     camera.quaternion.setFromEuler(_euler);

--- a/src/PointerLockControls_v2.js
+++ b/src/PointerLockControls_v2.js
@@ -100,7 +100,9 @@ class PointerLockControls extends EventDispatcher {
 
     lock() {
 
-        this.domElement.requestPointerLock();
+        this.domElement.requestPointerLock({
+            unadjustedMovement: true,  // fix random mouse jumping/skipping movement by using raw input no OS mouse acceleration
+        });
 
     }
 

--- a/src/scene-setup/_defaultCameraControl.js
+++ b/src/scene-setup/_defaultCameraControl.js
@@ -7,7 +7,7 @@ export function control_as_FPS(
     canvas,
 ) {
     const camControl = new PointerLockControls(camera, canvas);
-    camControl.pointerSpeed = 1;
+    camControl.pointerSpeed = .5;
     camControl._onMouseMove = null;
 
     // camControl.addEventListener('change', _ => {


### PR DESCRIPTION
fix bug on PointerLockControls (FPS view) mouse movement that randomly skip or jump around on Y and/or X axis.
fix by using raw mouse input without OS mouse acceleration.